### PR TITLE
ci(publish): use pyproject.toml for cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,15 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_LINUX: auto aarch64
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
remove setup-qemu-step as we only build amd64
